### PR TITLE
ci: Use gateway-api v0.5.0-rc1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         k8s:
           - v1.21
-          - v1.23
+          - v1.24
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           repository: kubernetes-sigs/gateway-api
-          ref: 3f4b981dd6669f67398d753a6f278b241d669953 # 0.5.0-dev
+          ref: 4f86f0bd65173b04dadb558f63fbbd53330736d2 # 0.5.0-rc1
           path: gateway-api
       - run: kubectl apply -k gateway-api/config/crd/experimental/
       # Setup just

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 (Unofficial) Rust bindings for the [Kubernetes Gateway API][site].
 
-Based on [gateway-api-v0.5.0-dev].
+Based on [gateway-api-v0.5.0-rc1].
 
 [![Crates.io][crate-badge]][crate-url]
 [![Documentation][docs-badge]][docs-url]
@@ -20,7 +20,7 @@ the *v1alpha2* types when the `experimental` feature is enabled.
 * Express validation constraints
 * Rustify/Linkify documentation
 
-[gateway-api-v0.5.0-dev]: https://github.com/kubernetes-sigs/gateway-api/tree/4f86f0bd65173b04dadb558f63fbbd53330736d2
+[gateway-api-v0.5.0-rc1]: https://github.com/kubernetes-sigs/gateway-api/tree/4f86f0bd65173b04dadb558f63fbbd53330736d2
 [site]: https://gateway-api.sigs.k8s.io/
 [crate-badge]: https://img.shields.io/crates/v/k8s-gateway-api.svg
 [crate-url]: https://crates.io/crates/k8s-gateway-api


### PR DESCRIPTION
* Update gateway-api sha to v0.5.0-rc1
* Update latest kubernetes version to v1.24

Signed-off-by: Oliver Gould <ver@buoyant.io>