### PR TITLE
build(deps): update to `kube` 0.78 and `k8s-openapi` 0.17

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "k8s-gateway-api",
-	"image": "ghcr.io/linkerd/dev:v34",
+	"image": "ghcr.io/linkerd/dev:v39",
 	"extensions": [
 		"DavidAnson.vscode-markdownlint",
 		"kokakiwi.vscode-just",

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,14 +13,14 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v39-action
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: linkerd/dev/actions/setup-tools@v39
       - run: just-dev lint-actions
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v39-action
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: linkerd/dev/actions/setup-tools@v39
       - run: just-dev check-action-images

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,14 +13,14 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v34-action
+    container: ghcr.io/linkerd/dev:v39-action
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just-dev lint-actions
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v34-action
+    container: ghcr.io/linkerd/dev:v39-action
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just-dev check-action-images

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,6 +27,7 @@ jobs:
         k8s:
           - v1.21
           - v1.25
+          - v1.26
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      # TODO(ver) Figure out how to use tools from the dev image.
       # Install just* tooling
       - uses: linkerd/dev/actions/setup-tools@v39
       # Configure the default Rust toolchain
@@ -38,7 +37,7 @@ jobs:
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | bash
       - run: k3d --version
-      - run: just-k3d K8S_VERSION=${{ matrix.k8s }} create
+      - run: just-k3d K8S_CHANNEL=${{ matrix.k8s }} create
       - run: kubectl version
       # Install CRDs
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
           curl --proto =https --tlsv1.3 -LsSv "$url" | tar zvxf - -C /usr/local/bin cargo-nextest
       - name: Install dev utils
         run: |
-          sha=574d6bab940a5fcfcd49169cd0b24ee72e2b5a04 # dev:v34
+          sha=ca8e6542459ff8225146e72bdcda68eb18aba07a # dev:v39
           cd /usr/local/bin
           for util in cargo k3d ; do
             curl --proto =https --tlsv1.3 -fLsSvO "https://raw.githubusercontent.com/linkerd/dev/$sha/bin/just-$util"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,8 @@ jobs:
           - v1.25
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    env:
+      K8S_CHANNEL: ${{ matrix.k8s }}
     steps:
       # Install just* tooling
       - uses: linkerd/dev/actions/setup-tools@v39
@@ -37,7 +39,7 @@ jobs:
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | bash
       - run: k3d --version
-      - run: just-k3d K8S_CHANNEL=${{ matrix.k8s }} create
+      - run: just-k3d create
       - run: kubectl version
       # Install CRDs
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,26 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # TODO(ver) Figure out how to use tools from the dev image.
-      - name: Install rust
-        run: |
-          rm -rf "$HOME/.cargo"
-          curl --proto =https --tlsv1.3 -fLsSv https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_VERSION}"
-          source "$HOME/.cargo/env"
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
-          cargo version
-      - name: Install cargo-nextest
-        run: |
-          url="https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ; \
-          curl --proto =https --tlsv1.3 -LsSv "$url" | tar zvxf - -C /usr/local/bin cargo-nextest
-      - name: Install dev utils
-        run: |
-          sha=ca8e6542459ff8225146e72bdcda68eb18aba07a # dev:v39
-          cd /usr/local/bin
-          for util in cargo k3d ; do
-            curl --proto =https --tlsv1.3 -fLsSvO "https://raw.githubusercontent.com/linkerd/dev/$sha/bin/just-$util"
-            chmod 755 "/usr/local/bin/just-$util"
-          done
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
+      # Install just* tooling
+      - uses: linkerd/dev/actions/setup-tools@v39
+      # Configure the default Rust toolchain
+      - uses: linkerd/dev/actions/setup-rust@v39
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | bash
       - run: k3d --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v34-rust
+    container: docker://ghcr.io/linkerd/dev:v39-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [meta, release]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v34-rust
+    container: docker://ghcr.io/linkerd/dev:v39-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - if: needs.meta.outputs.publish == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
   test:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v34-rust
+    container: docker://ghcr.io/linkerd/dev:v39-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch
@@ -55,7 +55,7 @@ jobs:
       contents: write
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v34-rust
+    container: docker://ghcr.io/linkerd/dev:v39-rust
     steps:
       - if: needs.meta.outputs.publish
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ default = []
 experimental = []
 
 [dependencies]
-kube = { version = "0.76", default-features = false, features = ["derive"] }
-k8s-openapi = { version = "0.16", features = ["schemars"] }
+kube = { version = "0.78", default-features = false, features = ["derive"] }
+k8s-openapi = { version = "0.17", features = ["schemars"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies.k8s-openapi]
-version = "0.16"
+version = "0.17"
 default-features = false
 features = ["v1_21"]
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,12 +6,12 @@ license = "Apache-2.0"
 publish = false
 
 [dev-dependencies]
-k8s-openapi = { version = "0.16", features = ["v1_21"] }
+k8s-openapi = { version = "0.17", features = ["v1_21"] }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 k8s-gateway-api = { path = ".." }
 
 [dev-dependencies.kube]
-version = "0.76"
+version = "0.78"
 default-features = false
 features = ["client", "openssl-tls", "runtime", "ws"]


### PR DESCRIPTION
This branch updates the dependency on `kube` to v0.78 and the dependency on `k8s-openapi` to 0.17. Since these dependencies have to be updated together, the Dependabot PRs for the update don't compile.

Therefore, this PR closes #37 and #36.

It was also necessary to update the devcontainer to the latest version, as `dev:v34` can no longer build the latest `openssl-sys` (a dependency of `kube-runtime`). The CI `integration` workflow was also updated to test against the latest Kubernetes version.