### PR TITLE
Add BackendObjectReference to BackendRef

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -144,6 +144,7 @@ pub struct BackendRef {
     pub weight: Option<u16>,
 
     /// BackendObjectReference references a Kubernetes object.
+    #[serde(flatten)]
     pub inner: BackendObjectReference,
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,5 +1,7 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
 
+use crate::BackendObjectReference;
+
 /// ParentReference identifies an API object (usually a Gateway) that can be considered
 /// a parent of this resource (usually a route). The only kind of parent resource
 /// with "Core" support is Gateway. This API may be extended in the future to
@@ -141,9 +143,8 @@ pub struct BackendRef {
     /// Support for this field varies based on the context where used.
     pub weight: Option<u16>,
 
-    pub name: String,
-
-    pub port: PortNumber,
+    /// BackendObjectReference references a Kubernetes object.
+    pub inner: BackendObjectReference,
 }
 
 /// RouteConditionType is a type of condition for a route.


### PR DESCRIPTION
BackendRef is a shared type used by routes that may match traffic to an arbitrary backend (other than the `Service` they are attached to). Our current bindings take a simplified approach of representing this by assuming the type is always a `Service`. Several fields are missing (gvk, namespace). This makes it hard to work with the types in code, and it makes it hard to add validation logic since the unserialized objects will be missing the gvk reference.

This change removes the fields in favour of adding an inner `BackendObjectReference` type that already exists in the bindings. This will make it so that any serialization takes into account the actual type of the backend the route has.

---

[Upstream type #1: BackendObjectReference](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1beta1/object_reference_types.go#L94)
[Upstream type #2: Shared BackendRef object](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1beta1/shared_types.go#L173)

I will follow this up with an issue to cross check all types against the upstream. For now, I added this in to help with the status controller work. I chose to represent it as an _inner_ field because we're doing something similar with `CommonRouteSpec` and `HttpRouteSpec` (see [upstream for example](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1beta1/httproute_types.go#L55-L57), basically use `inner` for embedded types).

https://github.com/linkerd/k8s-gateway-api-rs/blob/1b0af256e83e4d2e3e735eae66185d409a07f4ef/src/httproute.rs#L24-L27