### PR TITLE
Update to v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "integration"]
 
 [package]
 name = "k8s-gateway-api"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/linkerd/k8s-gateway-api"


### PR DESCRIPTION
Change updates the library to `0.12.0` to include the ResponseHeaderModifier filter.