### PR TITLE
update to `kube-rs` v0.85 and `k8s-openapi` v0.19

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,7 @@ jobs:
           - v1.21
           - v1.25
           - v1.26
+          - v1.27
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "integration"]
 
 [package]
 name = "k8s-gateway-api"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/linkerd/k8s-gateway-api"
@@ -16,17 +16,17 @@ default = []
 experimental = []
 
 [dependencies]
-kube = { version = "0.80", default-features = false, features = ["derive"] }
-k8s-openapi = { version = "0.17", features = ["schemars"] }
+kube = { version = "0.85", default-features = false, features = ["derive"] }
+k8s-openapi = { version = "0.19", features = ["schemars"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies.k8s-openapi]
-version = "0.17"
+version = "0.19"
 default-features = false
-features = ["v1_21"]
+features = ["v1_27"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
-features = ["experimental", "k8s-openapi/v1_25"]
+features = ["experimental", "k8s-openapi/v1_27"]

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,12 +6,12 @@ license = "Apache-2.0"
 publish = false
 
 [dev-dependencies]
-k8s-openapi = { version = "0.17", features = ["v1_21"] }
+k8s-openapi = { version = "0.19", features = ["v1_27"] }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 k8s-gateway-api = { path = ".." }
 
 [dev-dependencies.kube]
-version = "0.80"
+version = "0.85"
 default-features = false
 features = ["client", "openssl-tls", "runtime", "ws"]


### PR DESCRIPTION
This branch updates the dependency on `k8s-openapi` to v0.19 and the dependency on `kube-rs` to v0.85. This release of `k8s-openapi` also adds support for Kubernetes v1.27, so I've updated the CI integration workflow to run tests against that Kubernetes version as well as the existing ones.

Since this is a breaking change (these are public API deps), I've gone ahead and bumped the crate version to v0.13.0, as well.

Closes #52 
Closes #59