### PR TITLE
fix ListenerStatus is not renamed to camelCase

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -373,6 +373,7 @@ pub type GatewayConditionReason = String;
 
 /// ListenerStatus is the status associated with a Listener.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ListenerStatus {
     /// Name is the name of the Listener that this status corresponds to.
     pub name: SectionName,


### PR DESCRIPTION
`ListenerStatus` in `src/gateway.rs` is not renamed to camelCase. This causes issues when de-serializing response from api server. The supportedKinds field cannot be handled correctly.

This pull request fix this issue by adding rename macro before `ListenerStatus` struct.